### PR TITLE
ci: use deliveroo/semantic-release for release management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,35 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
 
+  release:
+    docker:
+      - image: deliveroo/semantic-release:1.0.0
+    steps:
+      - checkout
+      - run: semantic-release -r ${CIRCLE_REPOSITORY_URL}
+
+  commitlint:
+    docker:
+      - image: deliveroo/semantic-release:1.0.0
+    steps:
+      - checkout
+      - run: commitlint --from $(git rev-parse origin/master) --to $CIRCLE_SHA1 --verbose
+
 workflows:
   version: 2
   all:
     jobs:
       - build
+      - commitlint
       - lint
       - test
+      - release:
+          requires:
+            - build
+            - lint
+            - commitlint
+            - test
+          filters:
+            branches:
+              only:
+                - master

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "@commitlint/config-conventional"
+  ],
+  "rules": {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "ci",
+        "cosmetic",
+        "docs",
+        "feat",
+        "fix"
+      ]
+    ]
+  }
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,47 @@
+{
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING"
+          ]
+        },
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "writerOpts": {
+          "commitsSort": [
+            "subject",
+            "scope"
+          ]
+        },
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING"
+          ]
+        },
+        "preset": "conventionalcommits"
+      }
+    ],
+    "@semantic-release/changelog",
+    [
+      "@semantic-release/github",
+      {
+        "failComment": false,
+        "successComment": false,
+        "labels": false,
+        "releasedLabels": false,
+        "failTitle": false
+      }
+    ]
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Git
+
+This project uses
+[`semantic-release`](https://github.com/semantic-release/semantic-release)
+to derive and generate [a version number and changelog from the commit
+history](https://github.com/deliveroo/ad-platform/releases). This
+enables us to share user-facing changes with external stakeholders in
+a structured way, e.g.,
+https://deliveroo.slack.com/messages/ad-platform-releases.
+
+Git commit messages will be linted according to
+[https://www.conventionalcommits.org/en/v1.0.0/]. See
+[.commitlintrc.json](./.commitlintrc.json) for specific configuration.
+
+```
+<type>(<scope?>): <subject>
+```
+
+Note that any message with a `BREAKING CHANGE` will always create a
+new major version. Do this with care as a major version bump for Go
+libraries comes with some non-trivial overhead.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ func logging(next jsonrest.Endpoint) jsonrest.Endpoint {
     }
 }
 ```
+
+## Contributing
+
+Review the [contributing guidelines](./CONTRIBUTING.md).


### PR DESCRIPTION
This patch adds the requisite CI configuration to manage future releases with semantic-release.