### PR TITLE
Tests coverage increase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,8 @@ jobs:
           name: Run unit tests
           command: |
             trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-            go test -v ./... | tee ${TEST_RESULTS}/go-test.out
+            go test -coverprofile=test-coverage.out -v ./... | tee ${TEST_RESULTS}/go-test.out
+            go tool cover -html=test-coverage.out -o ${TEST_RESULTS}/test-coverage.html
       - store_artifacts:
           path: /tmp/test-results
           destination: raw-test-output

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ vendor
 
 # Tooling binaries.
 bin/
+
+# Test coverage output
+test-coverage.html

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ setup:  ## Download dependencies.
 
 .PHONY: test
 test:  ## Run tests.
-	@go test ./...
+	@go test -coverprofile=test-coverage.out ./...
+	@go tool cover -html=test-coverage.out -o test-coverage.html
 
 .PHONY: help
 help:

--- a/json_errors_test.go
+++ b/json_errors_test.go
@@ -67,6 +67,7 @@ func TestJSONType(t *testing.T) {
 	}{
 		{1, "integer"},
 		{1.2, "number"},
+		{true, "boolean"},
 		{[]string{}, "array"},
 		{[...]string{}, "array"},
 		{time.Now(), "time"},


### PR DESCRIPTION
Found that real test coverage is ~77% even if "goreportcard" report 100% - refresh of coverage shows error:
![image](https://user-images.githubusercontent.com/10694338/129869936-769bc5fa-23e0-4d89-8f52-c7b903fa6dd7.png)

Coverage before tests:
![image](https://user-images.githubusercontent.com/10694338/129869585-f735b7de-28a8-40df-883c-bb3e27e46a44.png)

Included changes:
*  updated tests to cover more cases
* updated make commands to generate HTML coverage file
* updated CI/CD to generate coverage files

Code coverage with updated test cases:

![image](https://user-images.githubusercontent.com/10694338/129869679-d487ced7-d54f-446e-918b-92b5f0bb09bd.png)


